### PR TITLE
Don't print require statements for development-only dependencies

### DIFF
--- a/libexec/decomposer/decomposer-install
+++ b/libexec/decomposer/decomposer-install
@@ -273,6 +273,12 @@ print_library_require() {
   local name="$1"
   local object="$2"
 
+  dev=$( jq -r '."development-only"' <<< "${object}" )
+
+  if [ "$dev" = "true" ] && [ $INSTALL_DEV_DEPENDENCIES = 0 ]; then
+    return 2
+  fi
+
   version=$( jq -r '.version' <<< "${object}" )
   printf "require_once '%s-%s.php';\\n" "${name}" "${version}"
 }

--- a/tests/install_no_dev.bats
+++ b/tests/install_no_dev.bats
@@ -87,5 +87,5 @@ BATS_TEST_NAME_PREFIX="$( test_suite_name ): "
 
   assert_lib_no_autoload_file Alpha-1.0
 
-  assert_project_autoload_file_without_check Alpha-1.0
+  assert_project_autoload_file_without_check
 }


### PR DESCRIPTION
Don't print require statements for development-only dependencies when using `--no-dev`