### PR TITLE
fix: reset remote if URL changed

### DIFF
--- a/libexec/decomposer/decomposer-install
+++ b/libexec/decomposer/decomposer-install
@@ -83,7 +83,7 @@ install_library() {
 
   cd "${library_target_dir}" || return 2
 
-  local revision revision_type revision_alt_type revision_reset
+  local revision revision_type revision_alt_type revision_reset default_remote
 
   revision=$( jq -r '.revision' <<< "${object}" )
   if [ "${revision}" = "null" ]; then
@@ -94,18 +94,25 @@ install_library() {
   revision_alt_type=$( git cat-file -t "v${revision}" 2> /dev/null )
   revision_reset=
 
-  if git branch -a | grep -q "/origin/${revision}"; then
-    revision_reset="origin/${revision}"
+  # use the origin for master as the default origin
+  # TODO: determine the default remote
+  default_remote="origin"
+  if [ "$( git config --get "remote.${default_remote}.url" )" != "${url}" ]; then
+    git remote set-url "$default_remote" "${url}"
+  fi
+
+  if git branch -a | grep -q "/${default_remote}/${revision}"; then
+    revision_reset="${default_remote}/${revision}"
   elif [ "${revision_type}" = 'commit' ] || [ "${revision_type}" = 'tag' ]; then
     revision_reset="${revision}"
   elif [ "${revision_alt_type}" = 'commit' ] || [ "${revision_alt_type}" = 'tag' ]; then
     revision_reset="v${revision}"
   fi
 
-  if [ -z "${just_cloned}" ] && [ "${revision_reset}" = "origin/${revision}" ] || [ -z "${revision_reset}" ]; then
+  if [ -z "${just_cloned}" ] && [ "${revision_reset}" = "${default_remote}/${revision}" ] || [ -z "${revision_reset}" ]; then
     # no need to fetch changes if we just cloned the repository
     # or we can already resolve a commit or tag
-    if ! git fetch origin &> /dev/null; then
+    if ! git fetch ${default_remote} &> /dev/null; then
       printf -v "${status_text_variable}" 'fetching changes failed'
       return 1
     fi
@@ -116,8 +123,8 @@ install_library() {
     revision_alt_type=$( git cat-file -t "v${revision}" 2> /dev/null )
     revision_reset=
 
-    if git branch -a | grep -q "/origin/${revision}"; then
-      revision_reset="origin/${revision}"
+    if git branch -a | grep -q "/${default_remote}/${revision}"; then
+      revision_reset="${default_remote}/${revision}"
     elif [ "${revision_type}" = 'commit' ] || [ "${revision_type}" = 'tag' ]; then
       revision_reset="${revision}"
     elif [ "${revision_alt_type}" = 'commit' ] || [ "${revision_alt_type}" = 'tag' ]; then

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -115,7 +115,42 @@ BATS_TEST_NAME_PREFIX="$( test_suite_name ): "
   assert_lib_installed Alpha-1.0 "${tag_alpha_lib_revision_hash}"
 }
 
-@test "existing library fetches new annotated tag" {
+@test "${SUITE_NAME}: existing library resets upstream" {
+  create_decomposer_json alpha_tag_version
+
+  create_repository alpha-lib
+
+  # create usual clone of library
+  git clone "${TEST_REPOS_DIR}/alpha-lib" "${DECOMPOSER_TARGET_DIR}/Alpha-1.0"
+
+  # create the requested tag only in the origin, so resolving it forces a
+  # fetch -- this is what exercises the remote reset before fetching
+  git -C "${TEST_REPOS_DIR}/alpha-lib" commit \
+    --allow-empty --message 'extra commit'
+  git -C "${TEST_REPOS_DIR}/alpha-lib" tag 1.0
+
+  local tag_alpha_lib_revision_hash=$(
+    git -C "${TEST_REPOS_DIR}/alpha-lib" \
+      rev-parse HEAD
+  )
+
+  # Change remote URL to a different one
+  git -C "${DECOMPOSER_TARGET_DIR}/Alpha-1.0" remote set-url origin https://moveagency.com
+
+  run_decomposer install
+  assert_success
+  assert_output "Installing Alpha...done"
+
+  assert_lib_installed Alpha-1.0 "${tag_alpha_lib_revision_hash}"
+
+  local install_remote=$(
+    git -C "${DECOMPOSER_TARGET_DIR}/Alpha-1.0" remote get-url origin
+  )
+
+  [ "${install_remote}" == "${TEST_REPOS_DIR}/alpha-lib" ]
+}
+
+@test "${SUITE_NAME}: existing library fetches new annotated tag" {
   create_decomposer_json alpha_tag_version
 
   create_repository alpha-lib


### PR DESCRIPTION
Resets the remote if the URL changed.

Supersedes #4. That PR's head branch lived on `SMillerDev/decomposer`, which has since been archived (read-only), so the branch there can no longer be updated. This re-opens the same change from a branch on this repository so it can be maintained and merged.

Original author: @SMillerDev (Sean Molenaar).

> Note from #4: "The test is incomplete" — worth confirming the test coverage before merge.
